### PR TITLE
Fix autohide logic

### DIFF
--- a/bar.py
+++ b/bar.py
@@ -1312,7 +1312,6 @@ class Bar(Window):
         self._dash_changed_callbacks: list[callable] = []
         self._hide_timeout = None
         self.monitor_name: str | None = None
-        self._wm_changed_timeout = None
         self._is_hovered = False
         self._had_windows = True
         
@@ -1586,7 +1585,7 @@ class Bar(Window):
             self._on_wm_changed()
         return False
 
-    def _has_windows_on_active_workspace(self) -> bool:
+    def _has_windows_on_active_workspace(self) -> bool | None:
         if self.monitor_name is None:
             return True
         windows = wm.windows or []
@@ -1596,11 +1595,10 @@ class Bar(Window):
             if not ws.is_active:
                 continue
             return any(w.workspace_id == ws.id for w in windows)
-        return True
+        return None
 
     def _do_show_if_empty(self):
-        self._wm_changed_timeout = None
-        if not self._has_windows_on_active_workspace():
+        if self._has_windows_on_active_workspace() is False:
             if self._hide_timeout is not None:
                 GLib.source_remove(self._hide_timeout)
                 self._hide_timeout = None
@@ -1616,16 +1614,13 @@ class Bar(Window):
             return
             
         has_windows = self._has_windows_on_active_workspace()
+        if has_windows is None:
+            return # Ignore intermediate WM states to prevent stuttering
         
         if not has_windows:
-            if self._wm_changed_timeout is None:
-                self._wm_changed_timeout = GLib.timeout_add(450, self._do_show_if_empty)
+            self._do_show_if_empty()
             self._had_windows = False
         else:
-            if self._wm_changed_timeout is not None:
-                GLib.source_remove(self._wm_changed_timeout)
-                self._wm_changed_timeout = None
-                
             if not self._had_windows:
                 if not (open_applet is not None and open_applet.is_visible()):
                     if not self._is_hovered:

--- a/bar.py
+++ b/bar.py
@@ -1314,6 +1314,7 @@ class Bar(Window):
         self.monitor_name: str | None = None
         self._wm_changed_timeout = None
         self._is_hovered = False
+        self._had_windows = True
         
         if bar_cfg is not None:
             self.bar_config = bar_cfg
@@ -1617,13 +1618,17 @@ class Bar(Window):
         if not has_windows:
             if self._wm_changed_timeout is None:
                 self._wm_changed_timeout = GLib.timeout_add(450, self._do_show_if_empty)
+            self._had_windows = False
         else:
             if self._wm_changed_timeout is not None:
                 GLib.source_remove(self._wm_changed_timeout)
                 self._wm_changed_timeout = None
-            if not (open_applet is not None and open_applet.is_visible()):
-                if not self._is_hovered:
-                    self._do_hide()
+                
+            if not self._had_windows:
+                if not (open_applet is not None and open_applet.is_visible()):
+                    if not self._is_hovered:
+                        self._do_hide()
+            self._had_windows = True
 
     def _on_bar_enter(self, _, event: Gdk.EventCrossing):
         if event.detail != Gdk.NotifyType.INFERIOR:

--- a/bar.py
+++ b/bar.py
@@ -1311,6 +1311,9 @@ class Bar(Window):
         self._bar_manager = bar_manager
         self._dash_changed_callbacks: list[callable] = []
         self._hide_timeout = None
+        self.monitor_name: str | None = None
+        self._wm_changed_timeout = None
+        self._is_hovered = False
         
         if bar_cfg is not None:
             self.bar_config = bar_cfg
@@ -1371,6 +1374,10 @@ class Bar(Window):
         if user_options.theme.blur:
             self._blur_ctx = enable_blur(self)
             GLib.timeout_add(1500, self._update_blur_region)
+
+        GLib.timeout_add(500, self._resolve_monitor_name)
+        wm.connect("notify::windows", lambda *_: self._on_wm_changed())
+        wm.connect("notify::workspaces", lambda *_: self._on_wm_changed())
 
     def _build_section(self, section_name: str) -> DraggableSection:
         entries: list = self.bar_config.get(section_name, [])
@@ -1541,7 +1548,8 @@ class Bar(Window):
         self.auto_hide = not self.auto_hide
         self.bar_config["auto_hide"] = self.auto_hide
         if self.auto_hide:
-            self._update_blur_region()
+            if self._blur_ctx:
+                self._update_blur_region()
             self._centerbox.add_style_class("auto-hide")
             self.exclusivity = "none"
             self._revealer.set_reveal_child(False)
@@ -1550,7 +1558,8 @@ class Bar(Window):
             self._centerbox.remove_style_class("auto-hide")
             self.exclusivity = "auto"
             self._revealer.set_reveal_child(True)
-            GLib.timeout_add(320, self._update_blur_region)
+            if self._blur_ctx:
+                GLib.timeout_add(320, self._update_blur_region)
         user_options.save()
 
     def _swap_bars(self):
@@ -1567,7 +1576,58 @@ class Bar(Window):
         a._set_alignment(b_align)
         b._set_alignment(a_align)
         
+    def _resolve_monitor_name(self) -> bool:
+        name = get_connector_from_monitor_id(self.monitor_id)
+        if name:
+            self.monitor_name = name
+            self._on_wm_changed()
+        return False
+
+    def _has_windows_on_active_workspace(self) -> bool:
+        if self.monitor_name is None:
+            return True
+        windows = wm.windows or []
+        for ws in wm.workspaces or []:
+            if ws.output != self.monitor_name:
+                continue
+            if not ws.is_active:
+                continue
+            return any(w.workspace_id == ws.id for w in windows)
+        return True
+
+    def _do_show_if_empty(self):
+        self._wm_changed_timeout = None
+        if not self._has_windows_on_active_workspace():
+            if self._hide_timeout is not None:
+                GLib.source_remove(self._hide_timeout)
+                self._hide_timeout = None
+            if not self._revealer.get_reveal_child():
+                self._revealer.set_reveal_child(True)
+                self._centerbox.add_style_class("revealed")
+        return False
+
+    def _on_wm_changed(self):
+        if not self.auto_hide or self.monitor_name is None:
+            return
+        if edit_mode.edit_mode:
+            return
+            
+        has_windows = self._has_windows_on_active_workspace()
+        
+        if not has_windows:
+            if self._wm_changed_timeout is None:
+                self._wm_changed_timeout = GLib.timeout_add(450, self._do_show_if_empty)
+        else:
+            if self._wm_changed_timeout is not None:
+                GLib.source_remove(self._wm_changed_timeout)
+                self._wm_changed_timeout = None
+            if not (open_applet is not None and open_applet.is_visible()):
+                if not self._is_hovered:
+                    self._do_hide()
+
     def _on_bar_enter(self, _, event: Gdk.EventCrossing):
+        if event.detail != Gdk.NotifyType.INFERIOR:
+            self._is_hovered = True
         if not self.auto_hide:
             return
         if event.detail == Gdk.NotifyType.INFERIOR:
@@ -1581,9 +1641,13 @@ class Bar(Window):
         self._centerbox.add_style_class("revealed")
 
     def _on_bar_leave(self, _, event: Gdk.EventCrossing):
+        if event.detail != Gdk.NotifyType.INFERIOR:
+            self._is_hovered = False
         if not self.auto_hide:
             return
         if event.detail == Gdk.NotifyType.INFERIOR:
+            return
+        if not self._has_windows_on_active_workspace():
             return
         if self._hide_timeout is not None:
             GLib.source_remove(self._hide_timeout)
@@ -1600,8 +1664,9 @@ class Bar(Window):
 
     def _do_hide(self):
         self.exclusivity = "none"
-        self._revealer.set_reveal_child(False)
-        self._centerbox.remove_style_class("revealed")
+        if self._revealer.get_reveal_child():
+            self._revealer.set_reveal_child(False)
+            self._centerbox.remove_style_class("revealed")
 
     def _on_edit_mode_changed(self, *_):
         if open_applet:

--- a/bar.py
+++ b/bar.py
@@ -1419,6 +1419,8 @@ class Bar(Window):
         return section
 
     def _update_blur_region(self) -> bool:
+        if self._blur_ctx is None:
+            return False
         set_blur_regions_from_widget(self._blur_ctx, self, accuracy=1, erode=0)
         return False
 


### PR DESCRIPTION
## **Description**
This PR improves the autohide behavior of the bar to be workspace-aware and fixes a pre-existing crash related to the blur context.
### **New Autohide Behavior:**
- Empty Workspaces: The bar will now automatically reveal itself and stay visible when there are no windows on the active workspace.
- Occupied Workspaces: When a window is opened (or you switch to a workspace with windows), the bar automatically hides itself, reverting to the standard hover-to-reveal behavior.
