### PR TITLE
bump nixpkgs to 26.05 and replace swww with awww

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1781626138,
-        "narHash": "sha256-+vQgpvT11v3CcxzLD4l2g7M4PU1cE/hN4aix8SvRIT0=",
+        "lastModified": 1784865682,
+        "narHash": "sha256-QV0t7y3ant10weKwlNoy3RMmOQ2rOr3/C0bgNkutoi8=",
         "owner": "Fabric-Development",
         "repo": "fabric",
-        "rev": "b7b0f9975f0cf161ccf81c1adfb181230d553f79",
+        "rev": "85cacf660b1a324525a4dd9b512521e55ef7f89b",
         "type": "github"
       },
       "original": {
@@ -23,16 +23,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1785858998,
+        "narHash": "sha256-fKCq5jphd6l/Ms6gc3dptkw/TcKLYub9lQE5g6rbbkc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "04607e1165ac22c5fde6dcc54c9e0b3c0487c555",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "caffyne-shell — a lightweight desktop shell powered by Fabric";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     utils.url = "github:numtide/flake-utils";
     fabric = {
       url = "github:Fabric-Development/fabric";
@@ -52,7 +52,7 @@
           swayidle
           wlsunset
           wf-recorder
-          swww
+          awww
         ];
 
         pythonEnv = pkgs.python3.withPackages (ps: with pkgs.python3Packages; [
@@ -102,7 +102,7 @@
             swayidle
             wlsunset
             wf-recorder
-            swww
+            awww
             gsettings-desktop-schemas
             hicolor-icon-theme
             adwaita-icon-theme

--- a/package.nix
+++ b/package.nix
@@ -26,7 +26,7 @@
 , swayidle
 , wlsunset
 , wf-recorder
-, swww
+, awww
 , gsettings-desktop-schemas
 , hicolor-icon-theme
 , adwaita-icon-theme
@@ -153,7 +153,7 @@ in stdenv.mkDerivation {
     gappsWrapperArgs+=(--set GI_TYPELIB_PATH "${typelibPath}")
     gappsWrapperArgs+=(--set LD_LIBRARY_PATH "${libraryPath}")
     gappsWrapperArgs+=(--set GTK_THEME "Adwaita")
-    gappsWrapperArgs+=(--prefix PATH : "${lib.makeBinPath [ pipewire bluez brightnessctl swayidle wlsunset wf-recorder swww ]}")
+    gappsWrapperArgs+=(--prefix PATH : "${lib.makeBinPath [ pipewire bluez brightnessctl swayidle wlsunset wf-recorder awww ]}")
     
     # Append host runtime schemas so your system-installed application assets resolve natively
     gappsWrapperArgs+=(--suffix XDG_DATA_DIRS : "/run/current-system/sw/share")


### PR DESCRIPTION
## Description
This PR updates the flake inputs to `nixos-26.05` and resolves deprecation warnings/errors related to upstream package renames