### PR TITLE
suppress glib macro deprecation warnings and unused parameter

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -46,7 +46,7 @@ let
     buildInputs = [ gtk3 ];
 
     buildPhase = ''
-      gcc -fPIC -Wall -Wextra -O2 -shared \
+      gcc -fPIC -Wall -Wextra -O2 -Wno-deprecated-declarations -DGLIB_DISABLE_DEPRECATION_WARNINGS -shared \
         -o libhacktk.so hacktk.c \
         $(pkg-config --cflags --libs gtk+-3.0) -lm
     '';

--- a/snippets/hacktk/lib/Makefile
+++ b/snippets/hacktk/lib/Makefile
@@ -1,5 +1,5 @@
 CC      := gcc
-CFLAGS  := -fPIC -Wall -Wextra -O2
+CFLAGS  := -fPIC -Wall -Wextra -O2 -Wno-deprecated-declarations -DGLIB_DISABLE_DEPRECATION_WARNINGS
 LIBS    := $(shell pkg-config --cflags --libs gtk+-3.0) -lm
 
 TARGET  := libhacktk.so

--- a/snippets/hacktk/lib/hacktk.c
+++ b/snippets/hacktk/lib/hacktk.c
@@ -1,3 +1,5 @@
+#define GLIB_DISABLE_DEPRECATION_WARNINGS 1
+
 #include <gtk/gtk.h>
 #include <math.h>
 


### PR DESCRIPTION
I fixed it for my custom shell, and I think now it will not show those warnings and it will work fine, I think.
 Review it first. 